### PR TITLE
Fix for older mouse scrollwheels

### DIFF
--- a/jquery.pagepiling.js
+++ b/jquery.pagepiling.js
@@ -601,7 +601,7 @@
 
                 if(isAccelerating && isScrollingVertically){
 	                //scrolling down?
-	                if (delta < 0) {
+	                if (delta <= 0) {
 	                    scrolling('down', scrollable);
 
 	                //scrolling up?


### PR DESCRIPTION
Changed delta operator to ‘less than or equal to’ for scrollwheels that
don’t change delta on small scrolls