### PR TITLE
Fixed flickering on firefox

### DIFF
--- a/jquery.pagepiling.css
+++ b/jquery.pagepiling.css
@@ -18,7 +18,9 @@ html, body {
     height:100%;
     position:absolute;
     width:100%;
-    backface-visibility: hidden; // fixes flickering in firefox
+    
+    /* fixes flickering in firefox*/
+    backface-visibility: hidden; 
 }
 .pp-easing {
     -webkit-transition: all 1000ms cubic-bezier(0.550, 0.085, 0.000, 0.990);

--- a/jquery.pagepiling.css
+++ b/jquery.pagepiling.css
@@ -18,6 +18,7 @@ html, body {
     height:100%;
     position:absolute;
     width:100%;
+    backface-visibility: hidden; // fixes flickering in firefox
 }
 .pp-easing {
     -webkit-transition: all 1000ms cubic-bezier(0.550, 0.085, 0.000, 0.990);


### PR DESCRIPTION
Some of the later versions of firefox (63, 64) experience a flickering issue with pagepiling transitions. Fixed using backface visibility: hidden.